### PR TITLE
fix properties typo

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1680,7 +1680,7 @@ components:
           type: object
       required:
       - name
-      - propertiers
+      - properties
       - provider
       type: object
     remoteParameters:
@@ -1692,7 +1692,7 @@ components:
           description: Provider-specific remote properties
           type: object
       required:
-      - propertiers
+      - properties
       - provider
       type: object
     repository:
@@ -1704,11 +1704,11 @@ components:
           description: Repository name
           type: string
         properties:
-          description: Client-specific propertiers
+          description: Client-specific properties
           type: object
       required:
       - name
-      - propertiers
+      - properties
       type: object
     repositoryStatus:
       example:

--- a/docs/Remote.md
+++ b/docs/Remote.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Provider** | **string** | Remote type | 
 **Name** | **string** | Name of remote | 
-**Properties** | [**map[string]interface{}**](.md) | Provider-specific remote properties | [optional] 
+**Properties** | [**map[string]interface{}**](.md) | Provider-specific remote properties | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/RemoteParameters.md
+++ b/docs/RemoteParameters.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Provider** | **string** | Remote type | 
-**Properties** | [**map[string]interface{}**](.md) | Provider-specific remote properties | [optional] 
+**Properties** | [**map[string]interface{}**](.md) | Provider-specific remote properties | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Repository.md
+++ b/docs/Repository.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** | Repository name | 
-**Properties** | [**map[string]interface{}**](.md) | Client-specific propertiers | [optional] 
+**Properties** | [**map[string]interface{}**](.md) | Client-specific properties | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/model_remote.go
+++ b/model_remote.go
@@ -15,5 +15,5 @@ type Remote struct {
 	// Name of remote
 	Name string `json:"name"`
 	// Provider-specific remote properties
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	Properties map[string]interface{} `json:"properties"`
 }

--- a/model_remote_parameters.go
+++ b/model_remote_parameters.go
@@ -13,5 +13,5 @@ type RemoteParameters struct {
 	// Remote type
 	Provider string `json:"provider"`
 	// Provider-specific remote properties
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	Properties map[string]interface{} `json:"properties"`
 }

--- a/model_repository.go
+++ b/model_repository.go
@@ -12,6 +12,6 @@ package titanclient
 type Repository struct {
 	// Repository name
 	Name string `json:"name"`
-	// Client-specific propertiers
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	// Client-specific properties
+	Properties map[string]interface{} `json:"properties"`
 }

--- a/titan.yml
+++ b/titan.yml
@@ -873,7 +873,7 @@ components:
       required:
         - provider
         - name
-        - propertiers
+        - properties
     remoteParameters:
       type: object
       properties:
@@ -885,7 +885,7 @@ components:
           description: Provider-specific remote properties
       required:
         - provider
-        - propertiers
+        - properties
     repository:
       type: object
       properties:
@@ -894,10 +894,10 @@ components:
           description: Repository name
         properties:
           type: object
-          description: Client-specific propertiers
+          description: Client-specific properties
       required:
         - name
-        - propertiers
+        - properties
     repositoryStatus:
       type: object
       properties:


### PR DESCRIPTION
## Proposed Changes

Fix typo in 'properties' name that was causing `omitempty` to be inappropriately specified.

## Testing

Inspected that `omitempty` is no longer present for `properties` fields.