### PR TITLE
getCommitStatus should be GET

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -713,7 +713,7 @@ paths:
       tags:
       - commits
   /v1/repositories/{repositoryName}/commits/{commitId}/status:
-    post:
+    get:
       operationId: getCommitStatus
       parameters:
       - description: Name of the repository

--- a/api_commits.go
+++ b/api_commits.go
@@ -436,7 +436,7 @@ GetCommitStatus Get commit status
 */
 func (a *CommitsApiService) GetCommitStatus(ctx _context.Context, repositoryName string, commitId string) (CommitStatus, *_nethttp.Response, error) {
 	var (
-		localVarHTTPMethod   = _nethttp.MethodPost
+		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string

--- a/docs/CommitsApi.md
+++ b/docs/CommitsApi.md
@@ -8,7 +8,7 @@ Method | HTTP request | Description
 [**CreateCommit**](CommitsApi.md#CreateCommit) | **Post** /v1/repositories/{repositoryName}/commits | Create new commit
 [**DeleteCommit**](CommitsApi.md#DeleteCommit) | **Delete** /v1/repositories/{repositoryName}/commits/{commitId} | Discard a past commit
 [**GetCommit**](CommitsApi.md#GetCommit) | **Get** /v1/repositories/{repositoryName}/commits/{commitId} | Get information for a specific commit
-[**GetCommitStatus**](CommitsApi.md#GetCommitStatus) | **Post** /v1/repositories/{repositoryName}/commits/{commitId}/status | Get commit status
+[**GetCommitStatus**](CommitsApi.md#GetCommitStatus) | **Get** /v1/repositories/{repositoryName}/commits/{commitId}/status | Get commit status
 [**ListCommits**](CommitsApi.md#ListCommits) | **Get** /v1/repositories/{repositoryName}/commits | Get commit history for a repository
 [**UpdateCommit**](CommitsApi.md#UpdateCommit) | **Post** /v1/repositories/{repositoryName}/commits/{commitId} | Update tags for a previous commit
 

--- a/titan.yml
+++ b/titan.yml
@@ -387,7 +387,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/repositoryName"
       - $ref: "#/components/parameters/commitId"
-    post:
+    get:
       summary: Get commit status
       operationId: getCommitStatus
       tags:


### PR DESCRIPTION
## Proposed Changes

While working on titan-server endtoend tests in golang, I discovered that we mistakenly had getCommitStatus() as POST, not GET.

## Testing

`go build ./...`