### PR TITLE
remote parameters are required for push and pull

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1318,7 +1318,7 @@ paths:
             schema:
               $ref: '#/components/schemas/remoteParameters'
         description: Provider specific parameters
-        required: false
+        required: true
       responses:
         201:
           content:
@@ -1389,7 +1389,7 @@ paths:
             schema:
               $ref: '#/components/schemas/remoteParameters'
         description: Provider specific parameters
-        required: false
+        required: true
       responses:
         201:
           content:

--- a/api_operations.go
+++ b/api_operations.go
@@ -435,7 +435,6 @@ func (a *OperationsApiService) ListOperations(ctx _context.Context, localVarOpti
 // PullOpts Optional parameters for the method 'Pull'
 type PullOpts struct {
     MetadataOnly optional.Bool
-    RemoteParameters optional.Interface
 }
 
 /*
@@ -444,12 +443,12 @@ Pull Start a pull operation
  * @param repositoryName Name of the repository
  * @param remoteName Name of the remote
  * @param commitId Commit identifier
+ * @param remoteParameters Provider specific parameters
  * @param optional nil or *PullOpts - Optional Parameters:
  * @param "MetadataOnly" (optional.Bool) -  Transfer only tag metadata
- * @param "RemoteParameters" (optional.Interface of RemoteParameters) -  Provider specific parameters
 @return Operation
 */
-func (a *OperationsApiService) Pull(ctx _context.Context, repositoryName string, remoteName string, commitId string, localVarOptionals *PullOpts) (Operation, *_nethttp.Response, error) {
+func (a *OperationsApiService) Pull(ctx _context.Context, repositoryName string, remoteName string, commitId string, remoteParameters RemoteParameters, localVarOptionals *PullOpts) (Operation, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -493,14 +492,7 @@ func (a *OperationsApiService) Pull(ctx _context.Context, repositoryName string,
 	}
 	var err error
 	// body params
-	if localVarOptionals != nil && localVarOptionals.RemoteParameters.IsSet() {
-		localVarOptionalRemoteParameters, localVarOptionalRemoteParametersok := localVarOptionals.RemoteParameters.Value().(RemoteParameters)
-		if !localVarOptionalRemoteParametersok {
-			return localVarReturnValue, nil, reportError("remoteParameters should be RemoteParameters")
-		}
-		localVarPostBody = &localVarOptionalRemoteParameters
-	}
-
+	localVarPostBody = &remoteParameters
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -577,7 +569,6 @@ func (a *OperationsApiService) Pull(ctx _context.Context, repositoryName string,
 // PushOpts Optional parameters for the method 'Push'
 type PushOpts struct {
     MetadataOnly optional.Bool
-    RemoteParameters optional.Interface
 }
 
 /*
@@ -586,12 +577,12 @@ Push Start a push operation
  * @param repositoryName Name of the repository
  * @param remoteName Name of the remote
  * @param commitId Commit identifier
+ * @param remoteParameters Provider specific parameters
  * @param optional nil or *PushOpts - Optional Parameters:
  * @param "MetadataOnly" (optional.Bool) -  Transfer only tag metadata
- * @param "RemoteParameters" (optional.Interface of RemoteParameters) -  Provider specific parameters
 @return Operation
 */
-func (a *OperationsApiService) Push(ctx _context.Context, repositoryName string, remoteName string, commitId string, localVarOptionals *PushOpts) (Operation, *_nethttp.Response, error) {
+func (a *OperationsApiService) Push(ctx _context.Context, repositoryName string, remoteName string, commitId string, remoteParameters RemoteParameters, localVarOptionals *PushOpts) (Operation, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -635,14 +626,7 @@ func (a *OperationsApiService) Push(ctx _context.Context, repositoryName string,
 	}
 	var err error
 	// body params
-	if localVarOptionals != nil && localVarOptionals.RemoteParameters.IsSet() {
-		localVarOptionalRemoteParameters, localVarOptionalRemoteParametersok := localVarOptionals.RemoteParameters.Value().(RemoteParameters)
-		if !localVarOptionalRemoteParametersok {
-			return localVarReturnValue, nil, reportError("remoteParameters should be RemoteParameters")
-		}
-		localVarPostBody = &localVarOptionalRemoteParameters
-	}
-
+	localVarPostBody = &remoteParameters
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/docs/OperationsApi.md
+++ b/docs/OperationsApi.md
@@ -163,7 +163,7 @@ No authorization required
 
 ## Pull
 
-> Operation Pull(ctx, repositoryName, remoteName, commitId, optional)
+> Operation Pull(ctx, repositoryName, remoteName, commitId, remoteParameters, optional)
 
 Start a pull operation
 
@@ -176,6 +176,7 @@ Name | Type | Description  | Notes
 **repositoryName** | **string**| Name of the repository | 
 **remoteName** | **string**| Name of the remote | 
 **commitId** | **string**| Commit identifier | 
+**remoteParameters** | [**RemoteParameters**](RemoteParameters.md)| Provider specific parameters | 
  **optional** | ***PullOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -188,8 +189,8 @@ Name | Type | Description  | Notes
 
 
 
+
  **metadataOnly** | **optional.Bool**| Transfer only tag metadata | 
- **remoteParameters** | [**optional.Interface of RemoteParameters**](RemoteParameters.md)| Provider specific parameters | 
 
 ### Return type
 
@@ -211,7 +212,7 @@ No authorization required
 
 ## Push
 
-> Operation Push(ctx, repositoryName, remoteName, commitId, optional)
+> Operation Push(ctx, repositoryName, remoteName, commitId, remoteParameters, optional)
 
 Start a push operation
 
@@ -224,6 +225,7 @@ Name | Type | Description  | Notes
 **repositoryName** | **string**| Name of the repository | 
 **remoteName** | **string**| Name of the remote | 
 **commitId** | **string**| Commit identifier | 
+**remoteParameters** | [**RemoteParameters**](RemoteParameters.md)| Provider specific parameters | 
  **optional** | ***PushOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -236,8 +238,8 @@ Name | Type | Description  | Notes
 
 
 
+
  **metadataOnly** | **optional.Bool**| Transfer only tag metadata | 
- **remoteParameters** | [**optional.Interface of RemoteParameters**](RemoteParameters.md)| Provider specific parameters | 
 
 ### Return type
 

--- a/titan.yml
+++ b/titan.yml
@@ -680,7 +680,7 @@ paths:
         - $ref: "#/components/parameters/metadataOnlyQuery"
       requestBody:
         description: Provider specific parameters
-        required: false
+        required: true
         content:
           application/json:
             schema:
@@ -712,7 +712,7 @@ paths:
         - $ref: "#/components/parameters/metadataOnlyQuery"
       requestBody:
         description: Provider specific parameters
-        required: false
+        required: true
         content:
           application/json:
             schema:
@@ -1008,7 +1008,6 @@ components:
       description: Name of the volume
       schema:
         type: string
-
     remoteParameters:
       name: titan-remote-parameters
       description: Remote-specific parameters
@@ -1016,7 +1015,6 @@ components:
       in: header
       schema:
         $ref: "#/components/schemas/remoteParameters"
-
     tagQuery:
       name: tag
       description: Tags (name or name=value) to search for


### PR DESCRIPTION
## Proposed Changes

There was a mistake in the openapi spec that declared remote parameters optional for push/pull. This is false, and failing to specify them will generate an exception.

## Testing

`go build ./...`